### PR TITLE
for macOS user, install swoole via pecl

### DIFF
--- a/get-started/installation.md
+++ b/get-started/installation.md
@@ -13,10 +13,13 @@ pecl install swoole
 ```
 ##### MacOS X \(macOS\) users
 
-> It is highly recommended to install Swoole on Mac OS X or macOS systems via homebrew
+> It is highly recommended to install php on Mac OS X or macOS systems via homebrew.
+>
+> And install swoole form PECL
 
 ``` bash
-brew install swoole
+brew install php # or brew install php@7.2 for php 7.2
+pecl install swoole
 ```
 
 #### Building swoole from sources


### PR DESCRIPTION
* homebrew-php has been deprecated(and removed all package)
* swoole doesn't exist in homebrew-core

So, I think install via PECL is possible.

---

And, don't forget update installation guide at <https://www.swoole.co.uk/>:
![install swoole](https://user-images.githubusercontent.com/1926185/39086687-3ce49df8-45c8-11e8-87dd-4b1aa080bfe8.png)
