### PR TITLE
"if" is EVIL and the HTTP_HOST should be set

### DIFF
--- a/modules/swoole-http-server/introduction.md
+++ b/modules/swoole-http-server/introduction.md
@@ -67,12 +67,15 @@ server {
     server_name localhost;
 
     location / {
+        try_files $uri @swoole;
+    }
+    location @swoole {
+        proxy_pass http://127.0.0.1:9501;
         proxy_http_version 1.1;
         proxy_set_header Connection "keep-alive";
         proxy_set_header X-Real-IP $remote_addr;
-        if (!-e $request_filename) {
-             proxy_pass http://127.0.0.1:9501;
-        }
+        proxy_set_header Host            $host;
     }
 }
+
 ```


### PR DESCRIPTION
According to https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/, "It’s generally a good idea to avoid [using if] if possible", so I have updated the code accordingly. Also, if we don't set the Host header, $_SERVER['HTTP_HOST'] will be the same as the proxy_pass host. I have added that as well.